### PR TITLE
Add opt-in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you want to customise the job name or opt out of one of the scanning jobs, th
 To be able to fully customise the pipeline job, replace the entry in `include` like so:
 ```yaml
 include:
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-checks/main/gitlab-trivy-checks-custom.yaml
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-checks/main/gitlab-trivy-checks.template.yaml
 ```
 
 Note the file name change at the end.
@@ -97,7 +97,7 @@ backend:container scanning:
   stage: container scanning
 ```
 
-The `-custom.yaml` file also includes [a `.config_scanning` job](https://github.com/ambient-innovation/gitlab-trivy-config-checks) which is not automatically included in the default YAML file for compatibility reasons.
+The `.template.yaml` file also includes [a `.config_scanning` job](https://github.com/ambient-innovation/gitlab-trivy-config-checks) which is not automatically included in the default YAML file for compatibility reasons.
 
 
 # More config options

--- a/gitlab-trivy-checks-custom.yaml
+++ b/gitlab-trivy-checks-custom.yaml
@@ -1,0 +1,33 @@
+include:
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks-custom.yaml
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/license-checks-custom.yaml
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-config-checks/main/config-checks-custom.yaml
+
+.check_trivy_scan_results:
+  stage: test
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine:latest
+  services: []
+  needs:
+    - container_scanning
+    - license_scanning
+    # List all your container/license scanning jobs here, one per line
+    # - container_scanning_frontend
+    # - license_scanning_frontend
+  tags:
+    - small-runner
+  before_script:
+    - apk update && apk add jq coreutils grep
+  script:
+    - echo "Step 1 - Merge all codeclimate reports from scanning jobs"
+    - jq -s 'add' gl-codeclimate*.json > gl-codeclimate.json
+    - echo "Step 2 - Check if there were any vulnerabilities and exit with a status code equal to the number of vulnerabilities"
+    # if . == null > all codeclimate-files were empty (null) -> No issues found, else find and count all type == "issue" elements
+    # Exit codes:
+    # 0 => jq returned true - no issues found
+    # 1 => jq returned false/null - found more than 0 issues
+    # 4 => jq found a syntax error in the merged JSON file
+    - jq -e 'if . == null then true else map(select(.type == "issue")) | length == 0 end' ./gl-codeclimate.json
+  # Enables CodeQuality Widget in Merge Request
+  artifacts:
+    paths:
+      - gl-codeclimate.json

--- a/gitlab-trivy-checks.template.yaml
+++ b/gitlab-trivy-checks.template.yaml
@@ -1,7 +1,7 @@
 include:
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks-custom.yaml
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/license-checks-custom.yaml
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-config-checks/main/config-checks-custom.yaml
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks.template.yaml
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/license-checks.template.yaml
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-config-checks/main/config-checks.template.yaml
 
 .check_trivy_scan_results:
   stage: test

--- a/gitlab-trivy-checks.yaml
+++ b/gitlab-trivy-checks.yaml
@@ -1,32 +1,11 @@
 include:
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks.yaml
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/license-checks.yaml 
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-checks/main/gitlab-trivy-checks.template.yaml
 
 check trivy scan results:
-  stage: test
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine:latest
-  services: []
-  needs:
-    - container_scanning
-    - license_scanning
-    # List all your container/license scanning jobs here, one per line
-    # - container_scanning_frontend
-    # - license_scanning_frontend
-  tags:
-    - small-runner
-  before_script:
-    - apk update && apk add jq coreutils grep
-  script:
-    - echo "Step 1 - Merge all codeclimate reports from scanning jobs"
-    - jq -s 'add' gl-codeclimate*.json > gl-codeclimate.json
-    - echo "Step 2 - Check if there were any vulnerabilities and exit with a status code equal to the number of vulnerabilities"
-    # if . == null > all codeclimate-files were empty (null) -> No issues found, else find and count all type == "issue" elements
-    # Exit codes:
-    # 0 => jq returned true - no issues found
-    # 1 => jq returned false/null - found more than 0 issues
-    # 4 => jq found a syntax error in the merged JSON file
-    - jq -e 'if . == null then true else map(select(.type == "issue")) | length == 0 end' ./gl-codeclimate.json
-  # Enables CodeQuality Widget in Merge Request
-  artifacts:
-    paths:
-      - gl-codeclimate.json
+  extends: [ .check_trivy_scan_results ]
+
+container_scanning:
+  extends: [ .license_scanning ]
+
+license_scanning:
+  extends: [ .license_scanning ]


### PR DESCRIPTION
- Add opt-in-based configuration file to allow full customisation.
- Document how to use and customise.
- Add config scanning to opt-in-based configuration.
- Add documentation and links on config scanning.

Before merging please merge:
- https://github.com/ambient-innovation/gitlab-trivy-security-checks/pull/9
- https://github.com/ambient-innovation/gitlab-trivy-license-checks/pull/18
- https://github.com/ambient-innovation/gitlab-trivy-config-checks/pull/3
...since the changes here reference files added there.