### PR TITLE
Deprecate standalone templates in favor of new combined scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# ⚠️ DEPRECATION WARNING ⚠️
-This template is DEPRECATED and will be removed in a future version.  
-
-
-
-
 # ⚠️ Migration Notice
 
 IMPORTANT: The individual template files (config-checks, license-checks, security-checks) are now DEPRECATED.

--- a/README.md
+++ b/README.md
@@ -1,109 +1,20 @@
-This repository adds a job to your GitLab-CI to visualize the findings from Dependency(Security) and License Scanning as a CodeQuality Report widget in your merge requests.
-
-[Dependency Scanning](https://github.com/ambient-innovation/gitlab-trivy-security-checks) is often considered part of Software Composition Analysis (SCA). SCA can contain aspects of inspecting the items your code uses. These items typically include application and system dependencies that are almost always imported from external sources, rather than sourced from items you wrote yourself.
-
-[License Scanning](https://github.com/ambient-innovation/gitlab-trivy-license-checks) is often considered part of Software Composition Analysis (SCA). SCA can contain aspects of inspecting the items your code uses. Open source software licenses define how you can use, modify and distribute the open source software. Thus, when selecting an open source package to merge to your code it is imperative to understand the types of licenses and the user restrictions the package falls under, which helps you mitigate any compliance issues.
-
-This config template can be included in your .gitlab-ci.yml to get both scanning jobs and the result visualisation for free.
-
-* [Config Scanning](https://github.com/ambient-innovation/gitlab-trivy-config-checks) for Dockerfiles and configuration files (such as Helm charts or AWS Cloudformation) is also available either separately (with a separate `include` entry) or as an opt-in (see *Full configuration* below).
-
-# Setup Instructions
-At the very top of your .gitlab-ci.yml either add or expand the include: section so it looks similar to this:  
-```yaml
-include:
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-checks/main/gitlab-trivy-checks.yaml
-  # There might be more includes here, usually starting with template like the following:
-  # - template: 'Workflows/Branch-Pipelines.gitlab-ci.yml'
-```
-
-You will also need to have at least one stage called test in your top-level stages config for the default configuration:  
-```yaml
-stages:
-  - prebuild
-  - build
-  - test
-  - deploy
-```
-
-The **test** stage has to come after the docker image has already been built and pushed to the registry or the scanner will not work.
-
-Last but not least you need one job within that test stage going by the name `license_scanning` and one with the name `container_scanning`. A minimal config looks like this:  
-```yaml
-license_scanning:
-  variables:
-    IMAGE: $IMAGE_TAG_BACKEND
-container_scanning:
-  variables:
-    IMAGE: $IMAGE_TAG_BACKEND    
-```
-
-The example shown here will overwrite the `scanning` jobs from the template and tell them to
-
-a) scan an image as specified in the `IMAGE_TAG_BACKEND` variable,\
-b) perform a simple license scan\
-c) only report errors with a level of HIGH,CRITICAL or UNKNOWN.
+# ⚠️ DEPRECATION WARNING ⚠️
+This template is DEPRECATED and will be removed in a future version.  
 
 
-# Errors in Pipeline
-The `check trivy scan results` Job is built to be secure by default and will cause the job to fail in your pipeline if it finds any issues in either security or license scanning. The Job exits with a status code resembling the number of issues found.  
-Sometimes it's unavoidable to have security/license issues in your project, in those cases, you can decide to allow the job to fail by overriding the `check trivy scan results` job in your gitlab-ci.yml and enabling the `allow_failure` option.  
-Example:  
-```yaml
-check trivy scan results:
-  allow_failure: true
-```
 
 
-# Customising the pipeline job
-## Running the job in a different stage
-If you wish to run the `*_scanning` jobs in another stage than "`test`" (as they do by default) simply copy the above code to your .gitlab-ci.yml file and add the keyword `stage` with your custom stage name.
+# ⚠️ Migration Notice
 
-Example for minimal stage-overwrite setup:
-```yaml
-license_scanning:
-  stage: my-custom-stage
-```
+IMPORTANT: The individual template files (config-checks, license-checks, security-checks) are now DEPRECATED.
 
-You can do the same for `check trivy scan results` if needed.
+Please migrate to the new unified trivy-scanning.template.yaml, which provides:
 
-## Full customisation
-If you want to customise the job name or opt out of one of the scanning jobs, the above method will not work because the original job will be added to the pipeline in addition to any job that extends it.
+    Better plugin architecture
+    More flexible configuration options
+    Unified scanning approach
+    Future-proof design
 
-To be able to fully customise the pipeline job, replace the entry in `include` like so:
-```yaml
-include:
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-checks/main/gitlab-trivy-checks.template.yaml
-```
+The deprecated templates will show migration instructions when used.
 
-Note the file name change at the end.
-
-With this file, no job will be added automatically anymore, and to enable each job you will have to extend it. For example:
-```yaml
-# Any name goes.
-scan results:
-  # Notice the . at the start and _ instead of spaces:
-  extends: [ .check_trivy_scan_results ]
-  # Any stage you like, you don't need to include a `test` stage anymore.
-  stage: security scan
-
-# You can now have a uniform interface for different parts of the application:
-frontend:container scanning:
-  extends: [ .container_scanning ]
-  stage: container scanning
-
-backend:container scanning:
-  extends: [ .container_scanning ]
-  stage: container scanning
-```
-
-The `.template.yaml` file also includes [a `.config_scanning` job](https://github.com/ambient-innovation/gitlab-trivy-config-checks) which is not automatically included in the default YAML file for compatibility reasons.
-
-
-# More config options
-You can configure each of the scanner jobs with a ton of options not mentioned here.   
-Please check the corresponding repositories and the trivy documentation for more config options.
-* [Container Scanning](https://github.com/ambient-innovation/gitlab-trivy-security-checks)
-* [License Scanning](https://github.com/ambient-innovation/gitlab-trivy-license-checks)
-* [Config Scanning](https://github.com/ambient-innovation/gitlab-trivy-config-checks)
-* [Trivy Documentation](https://aquasecurity.github.io/trivy/)
+There's an all-in-one replacement over at https://github.com/ambient-innovation/gitlab-trivy-codequality-template

--- a/gitlab-trivy-checks.template.yaml
+++ b/gitlab-trivy-checks.template.yaml
@@ -4,15 +4,23 @@
 
 # For more information, see: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest
 
-.container_scanning:
-  extends: .trivy_scanning
-  variables:
-    # Deprecated: Use the new trivy_scanning template directly
-    PLUGIN_SEVERITY_VULN: "HIGH,CRITICAL"
-    PLUGIN_SEVERITY_MISCONFIG: "HIGH,CRITICAL"
-    PLUGIN_PKG_TYPES_VULN: "os,library"
-    # Override scanner types for security scanning
-    TRIVY_SCANNERS: "vuln,misconfig"
+include:
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks.template.yaml
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/license-checks.template.yaml
+  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-config-checks/main/config-checks.template.yaml
+
+.check_trivy_scan_results:
+  stage: test
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine:latest
+  services: []
+  needs:
+    - container_scanning
+    - license_scanning
+    # List all your container/license scanning jobs here, one per line
+    # - container_scanning_frontend
+    # - license_scanning_frontend
+  tags:
+    - small-runner
   before_script:
     # Show deprecation warning
     - echo "⚠️  WARNING: The .container_scanning template is DEPRECATED!"
@@ -21,60 +29,18 @@
     - echo "⚠️  This template will be removed in a future version."
     - echo "⚠️  Note: Security scanning supports both IMAGE and DIRECTORY variables!"
     - echo ""
-    # Call parent before_script
-    - !reference [.trivy_scanning, before_script]
-
-.license_scanning:
-  extends: .trivy_scanning
-  variables:
-    # Deprecated: Use the new trivy_scanning template directly
-    PLUGIN_SEVERITY_LICENSE: "HIGH,CRITICAL,UNKNOWN"
-    PLUGIN_PKG_TYPES_LICENSE: "library"
-    # Override scanner types for license-only scanning
-    TRIVY_SCANNERS: "license"
-  before_script:
-    # Show deprecation warning
-    - echo "⚠️  WARNING: The .license_scanning template is DEPRECATED!"
-    - echo "⚠️  Please migrate to .trivy_scanning template."
-    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest"
-    - echo "⚠️  This template will be removed in a future version."
-    - echo "⚠️  Note: License scanning requires the IMAGE variable to be set!"
-    - echo ""
-    # Call parent before_script
-    - !reference [.trivy_scanning, before_script]
-
-.config_scanning:
-  extends: .trivy_scanning
-  variables:
-    # Deprecated: Use the new trivy_scanning template directly
-    PLUGIN_SEVERITY_MISCONFIG: "MEDIUM,HIGH,CRITICAL,UNKNOWN"
-    PLUGIN_PKG_TYPES_MISCONFIG: "library, os"
-    # Override scanner types for config-only scanning
-    TRIVY_SCANNERS: "misconfig"
-  before_script:
-    # Show deprecation warning
-    - echo "⚠️  WARNING: The .config_scanning template is DEPRECATED!"
-    - echo "⚠️  Please migrate to .trivy_scanning template."
-    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest"
-    - echo "⚠️  This template will be removed in a future version."
-    - echo ""
-    # Call parent before_script
-    - !reference [.trivy_scanning, before_script]
-
-.check_trivy_scan:
-  stage: test
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine:latest
-  services: []
-  needs:
-    - container_scanning
-    - license_scanning
-    - config_scanning
-    # List all your container/license scanning jobs here, one per line
-    # - container_scanning_frontend
-    # - license_scanning_frontend
-  tags:
-    - small-runner
-
-# Include the new unified template
-include:
-  - remote: 'https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/download/v25.08.06.3/trivy-scanning.template.yaml'
+    - apk update && apk add jq coreutils grep
+  script:
+    - echo "Step 1 - Merge all codeclimate reports from scanning jobs"
+    - jq -s 'add' gl-codeclimate*.json > gl-codeclimate.json
+    - echo "Step 2 - Check if there were any vulnerabilities and exit with a status code equal to the number of vulnerabilities"
+    # if . == null > all codeclimate-files were empty (null) -> No issues found, else find and count all type == "issue" elements
+    # Exit codes:
+    # 0 => jq returned true - no issues found
+    # 1 => jq returned false/null - found more than 0 issues
+    # 4 => jq found a syntax error in the merged JSON file
+    - jq -e 'if . == null then true else map(select(.type == "issue")) | length == 0 end' ./gl-codeclimate.json
+  # Enables CodeQuality Widget in Merge Request
+  artifacts:
+    paths:
+      - gl-codeclimate.json

--- a/gitlab-trivy-checks.template.yaml
+++ b/gitlab-trivy-checks.template.yaml
@@ -1,9 +1,47 @@
-include:
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks.template.yaml
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/license-checks.template.yaml
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-config-checks/main/config-checks.template.yaml
+# ⚠️ DEPRECATION WARNING ⚠️
+# This template is DEPRECATED and will be removed in a future version.
+# Please migrate to the new unified trivy-scanning.template.yaml
 
-.check_trivy_scan_results:
+.container_scanning:
+  extends: .trivy_scanning
+  variables:
+    # Deprecated: Use the new trivy_scanning template directly
+    PLUGIN_SEVERITY_VULN: "HIGH,CRITICAL"
+    PLUGIN_SEVERITY_MISCONFIG: "HIGH,CRITICAL"
+    PLUGIN_PKG_TYPES_VULN: "os,library"
+    # Override scanner types for security scanning
+    TRIVY_SCANNERS: "vuln,misconfig"
+  before_script:
+    # Show deprecation warning
+    - echo "⚠️  WARNING: The .container_scanning template is DEPRECATED!"
+    - echo "⚠️  Please migrate to .trivy_scanning template."
+    - echo "⚠️  See migration guide: https://github.com/$CI_PROJECT_PATH/releases/latest"
+    - echo "⚠️  This template will be removed in a future version."
+    - echo "⚠️  Note: Security scanning supports both IMAGE and DIRECTORY variables!"
+    - echo ""
+    # Call parent before_script
+    - !reference [.trivy_scanning, before_script]
+
+.license_scanning:
+  extends: .trivy_scanning
+  variables:
+    # Deprecated: Use the new trivy_scanning template directly
+    PLUGIN_SEVERITY_LICENSE: "HIGH,CRITICAL,UNKNOWN"
+    PLUGIN_PKG_TYPES_LICENSE: "library,os"
+    # Override scanner types for license-only scanning
+    TRIVY_SCANNERS: "license"
+  before_script:
+    # Show deprecation warning
+    - echo "⚠️  WARNING: The .license_scanning template is DEPRECATED!"
+    - echo "⚠️  Please migrate to .trivy_scanning template."
+    - echo "⚠️  See migration guide: https://github.com/$CI_PROJECT_PATH/releases/latest"
+    - echo "⚠️  This template will be removed in a future version."
+    - echo "⚠️  Note: License scanning requires the IMAGE variable to be set!"
+    - echo ""
+    # Call parent before_script
+    - !reference [.trivy_scanning, before_script]
+
+.check_trivy_scan:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine:latest
   services: []
@@ -31,3 +69,7 @@ include:
   artifacts:
     paths:
       - gl-codeclimate.json
+
+# Include the new unified template
+include:
+  - remote: 'https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest/download/trivy-scanning.template.yaml'

--- a/gitlab-trivy-checks.template.yaml
+++ b/gitlab-trivy-checks.template.yaml
@@ -2,7 +2,7 @@
 # This template is DEPRECATED and will be removed in a future version.
 # Please migrate to the new unified trivy-scanning.template.yaml
 
-# For more information, see: https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest
+# For more information, see: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest
 
 .container_scanning:
   extends: .trivy_scanning
@@ -17,7 +17,7 @@
     # Show deprecation warning
     - echo "⚠️  WARNING: The .container_scanning template is DEPRECATED!"
     - echo "⚠️  Please migrate to .trivy_scanning template."
-    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest"
+    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest"
     - echo "⚠️  This template will be removed in a future version."
     - echo "⚠️  Note: Security scanning supports both IMAGE and DIRECTORY variables!"
     - echo ""
@@ -36,9 +36,27 @@
     # Show deprecation warning
     - echo "⚠️  WARNING: The .license_scanning template is DEPRECATED!"
     - echo "⚠️  Please migrate to .trivy_scanning template."
-    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest"
+    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest"
     - echo "⚠️  This template will be removed in a future version."
     - echo "⚠️  Note: License scanning requires the IMAGE variable to be set!"
+    - echo ""
+    # Call parent before_script
+    - !reference [.trivy_scanning, before_script]
+
+.config_scanning:
+  extends: .trivy_scanning
+  variables:
+    # Deprecated: Use the new trivy_scanning template directly
+    PLUGIN_SEVERITY_MISCONFIG: "MEDIUM,HIGH,CRITICAL,UNKNOWN"
+    PLUGIN_PKG_TYPES_MISCONFIG: "library, os"
+    # Override scanner types for config-only scanning
+    TRIVY_SCANNERS: "misconfig"
+  before_script:
+    # Show deprecation warning
+    - echo "⚠️  WARNING: The .config_scanning template is DEPRECATED!"
+    - echo "⚠️  Please migrate to .trivy_scanning template."
+    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest"
+    - echo "⚠️  This template will be removed in a future version."
     - echo ""
     # Call parent before_script
     - !reference [.trivy_scanning, before_script]
@@ -50,6 +68,7 @@
   needs:
     - container_scanning
     - license_scanning
+    - config_scanning
     # List all your container/license scanning jobs here, one per line
     # - container_scanning_frontend
     # - license_scanning_frontend
@@ -58,4 +77,4 @@
 
 # Include the new unified template
 include:
-  - remote: 'ttps://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/download/v25.08.05.0/trivy-scanning.template.yaml'
+  - remote: 'https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/download/v25.08.06.3/trivy-scanning.template.yaml'

--- a/gitlab-trivy-checks.template.yaml
+++ b/gitlab-trivy-checks.template.yaml
@@ -58,4 +58,4 @@
 
 # Include the new unified template
 include:
-  - remote: 'https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest/download/trivy-scanning.template.yaml'
+  - remote: 'ttps://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/download/v25.08.05.0/trivy-scanning.template.yaml'

--- a/gitlab-trivy-checks.template.yaml
+++ b/gitlab-trivy-checks.template.yaml
@@ -2,6 +2,8 @@
 # This template is DEPRECATED and will be removed in a future version.
 # Please migrate to the new unified trivy-scanning.template.yaml
 
+# For more information, see: https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest
+
 .container_scanning:
   extends: .trivy_scanning
   variables:
@@ -15,7 +17,7 @@
     # Show deprecation warning
     - echo "⚠️  WARNING: The .container_scanning template is DEPRECATED!"
     - echo "⚠️  Please migrate to .trivy_scanning template."
-    - echo "⚠️  See migration guide: https://github.com/$CI_PROJECT_PATH/releases/latest"
+    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest"
     - echo "⚠️  This template will be removed in a future version."
     - echo "⚠️  Note: Security scanning supports both IMAGE and DIRECTORY variables!"
     - echo ""
@@ -27,14 +29,14 @@
   variables:
     # Deprecated: Use the new trivy_scanning template directly
     PLUGIN_SEVERITY_LICENSE: "HIGH,CRITICAL,UNKNOWN"
-    PLUGIN_PKG_TYPES_LICENSE: "library,os"
+    PLUGIN_PKG_TYPES_LICENSE: "library"
     # Override scanner types for license-only scanning
     TRIVY_SCANNERS: "license"
   before_script:
     # Show deprecation warning
     - echo "⚠️  WARNING: The .license_scanning template is DEPRECATED!"
     - echo "⚠️  Please migrate to .trivy_scanning template."
-    - echo "⚠️  See migration guide: https://github.com/$CI_PROJECT_PATH/releases/latest"
+    - echo "⚠️  See migration guide: https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest"
     - echo "⚠️  This template will be removed in a future version."
     - echo "⚠️  Note: License scanning requires the IMAGE variable to be set!"
     - echo ""
@@ -53,22 +55,6 @@
     # - license_scanning_frontend
   tags:
     - small-runner
-  before_script:
-    - apk update && apk add jq coreutils grep
-  script:
-    - echo "Step 1 - Merge all codeclimate reports from scanning jobs"
-    - jq -s 'add' gl-codeclimate*.json > gl-codeclimate.json
-    - echo "Step 2 - Check if there were any vulnerabilities and exit with a status code equal to the number of vulnerabilities"
-    # if . == null > all codeclimate-files were empty (null) -> No issues found, else find and count all type == "issue" elements
-    # Exit codes:
-    # 0 => jq returned true - no issues found
-    # 1 => jq returned false/null - found more than 0 issues
-    # 4 => jq found a syntax error in the merged JSON file
-    - jq -e 'if . == null then true else map(select(.type == "issue")) | length == 0 end' ./gl-codeclimate.json
-  # Enables CodeQuality Widget in Merge Request
-  artifacts:
-    paths:
-      - gl-codeclimate.json
 
 # Include the new unified template
 include:

--- a/gitlab-trivy-checks.yaml
+++ b/gitlab-trivy-checks.yaml
@@ -15,5 +15,5 @@ license_scanning:
 config_scanning:
   extends: .config_scanning
 
-check_trivy_scan:
-  extends: .check_trivy_scan
+check trivy scan results:
+  extends: .check_trivy_scan_results

--- a/gitlab-trivy-checks.yaml
+++ b/gitlab-trivy-checks.yaml
@@ -7,7 +7,7 @@ include:
   - remote: 'https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks.template.yaml'
 
 .container_scanning:
-  extends: .ontainer_scanning
+  extends: .container_scanning
 
 license_scanning:
   extends: .license_scanning

--- a/gitlab-trivy-checks.yaml
+++ b/gitlab-trivy-checks.yaml
@@ -1,33 +1,46 @@
-include:
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks.yaml
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/license-checks.yaml
-  - remote: https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-config-checks/main/config-checks.yaml
+# ⚠️ DEPRECATION WARNING ⚠️
+# This template is DEPRECATED and will be removed in a future version.
+# Please migrate to the new unified trivy-scanning.template.yaml
 
-check trivy scan results:
-  stage: test
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine:latest
-  services: []
-  needs:
-    - container_scanning
-    - license_scanning
-    # List all your container/license scanning jobs here, one per line
-    # - container_scanning_frontend
-    # - license_scanning_frontend
-  tags:
-    - small-runner
+# Include the new unified template
+include:
+  - remote: 'https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest/download/trivy-scanning.template.yaml'
+
+container_scanning:
+  extends: .trivy_scanning
+  variables:
+    # Deprecated: Use the new trivy_scanning template directly
+    PLUGIN_SEVERITY_VULN: "HIGH,CRITICAL"
+    PLUGIN_SEVERITY_MISCONFIG: "HIGH,CRITICAL"
+    PLUGIN_PKG_TYPES_VULN: "os,library"
+    # Override scanner types for security scanning
+    TRIVY_SCANNERS: "vuln,misconfig"
   before_script:
-    - apk update && apk add jq coreutils grep
-  script:
-    - echo "Step 1 - Merge all codeclimate reports from scanning jobs"
-    - jq -s 'add' gl-codeclimate*.json > gl-codeclimate.json
-    - echo "Step 2 - Check if there were any vulnerabilities and exit with a status code equal to the number of vulnerabilities"
-    # if . == null > all codeclimate-files were empty (null) -> No issues found, else find and count all type == "issue" elements
-    # Exit codes:
-    # 0 => jq returned true - no issues found
-    # 1 => jq returned false/null - found more than 0 issues
-    # 4 => jq found a syntax error in the merged JSON file
-    - jq -e 'if . == null then true else map(select(.type == "issue")) | length == 0 end' ./gl-codeclimate.json
-  # Enables CodeQuality Widget in Merge Request
-  artifacts:
-    paths:
-      - gl-codeclimate.json
+    # Show deprecation warning
+    - echo "⚠️  WARNING: The .container_scanning template is DEPRECATED!"
+    - echo "⚠️  Please migrate to .trivy_scanning template."
+    - echo "⚠️  See migration guide: https://github.com/$CI_PROJECT_PATH/releases/latest"
+    - echo "⚠️  This template will be removed in a future version."
+    - echo "⚠️  Note: Security scanning supports both IMAGE and DIRECTORY variables!"
+    - echo ""
+    # Call parent before_script
+    - !reference [.trivy_scanning, before_script]
+
+license_scanning:
+  extends: .trivy_scanning
+  variables:
+    # Deprecated: Use the new trivy_scanning template directly
+    PLUGIN_SEVERITY_LICENSE: "HIGH,CRITICAL,UNKNOWN"
+    PLUGIN_PKG_TYPES_LICENSE: "library,os"
+    # Override scanner types for license-only scanning
+    TRIVY_SCANNERS: "license"
+  before_script:
+    # Show deprecation warning
+    - echo "⚠️  WARNING: The .license_scanning template is DEPRECATED!"
+    - echo "⚠️  Please migrate to .trivy_scanning template."
+    - echo "⚠️  See migration guide: https://github.com/$CI_PROJECT_PATH/releases/latest"
+    - echo "⚠️  This template will be removed in a future version."
+    - echo "⚠️  Note: License scanning requires the IMAGE variable to be set!"
+    - echo ""
+    # Call parent before_script
+    - !reference [.trivy_scanning, before_script]

--- a/gitlab-trivy-checks.yaml
+++ b/gitlab-trivy-checks.yaml
@@ -2,6 +2,8 @@
 # This template is DEPRECATED and will be removed in a future version.
 # Please migrate to the new unified trivy-scanning.template.yaml
 
+# For more information, see: https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest
+
 # Include the new unified template
 include:
   - remote: 'https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest/download/trivy-scanning.template.yaml'

--- a/gitlab-trivy-checks.yaml
+++ b/gitlab-trivy-checks.yaml
@@ -4,7 +4,7 @@
 
 # For more information, see: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest
 include:
-  - remote: 'https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks.template.yaml'
+  - remote: 'https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-checks/main/gitlab-trivy-checks.template.yaml'
 
 .container_scanning:
   extends: .container_scanning

--- a/gitlab-trivy-checks.yaml
+++ b/gitlab-trivy-checks.yaml
@@ -2,47 +2,18 @@
 # This template is DEPRECATED and will be removed in a future version.
 # Please migrate to the new unified trivy-scanning.template.yaml
 
-# For more information, see: https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest
-
-# Include the new unified template
+# For more information, see: https://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/latest
 include:
-  - remote: 'ttps://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/download/v25.08.05.0/trivy-scanning.template.yaml'
+  - remote: 'https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-security-checks/main/security-checks.template.yaml'
 
-container_scanning:
-  extends: .trivy_scanning
-  variables:
-    # Deprecated: Use the new trivy_scanning template directly
-    PLUGIN_SEVERITY_VULN: "HIGH,CRITICAL"
-    PLUGIN_SEVERITY_MISCONFIG: "HIGH,CRITICAL"
-    PLUGIN_PKG_TYPES_VULN: "os,library"
-    # Override scanner types for security scanning
-    TRIVY_SCANNERS: "vuln,misconfig"
-  before_script:
-    # Show deprecation warning
-    - echo "⚠️  WARNING: The .container_scanning template is DEPRECATED!"
-    - echo "⚠️  Please migrate to .trivy_scanning template."
-    - echo "⚠️  See migration guide: https://github.com/$CI_PROJECT_PATH/releases/latest"
-    - echo "⚠️  This template will be removed in a future version."
-    - echo "⚠️  Note: Security scanning supports both IMAGE and DIRECTORY variables!"
-    - echo ""
-    # Call parent before_script
-    - !reference [.trivy_scanning, before_script]
+.container_scanning:
+  extends: .ontainer_scanning
 
 license_scanning:
-  extends: .trivy_scanning
-  variables:
-    # Deprecated: Use the new trivy_scanning template directly
-    PLUGIN_SEVERITY_LICENSE: "HIGH,CRITICAL,UNKNOWN"
-    PLUGIN_PKG_TYPES_LICENSE: "library,os"
-    # Override scanner types for license-only scanning
-    TRIVY_SCANNERS: "license"
-  before_script:
-    # Show deprecation warning
-    - echo "⚠️  WARNING: The .license_scanning template is DEPRECATED!"
-    - echo "⚠️  Please migrate to .trivy_scanning template."
-    - echo "⚠️  See migration guide: https://github.com/$CI_PROJECT_PATH/releases/latest"
-    - echo "⚠️  This template will be removed in a future version."
-    - echo "⚠️  Note: License scanning requires the IMAGE variable to be set!"
-    - echo ""
-    # Call parent before_script
-    - !reference [.trivy_scanning, before_script]
+  extends: .license_scanning
+
+config_scanning:
+  extends: .config_scanning
+
+check_trivy_scan:
+  extends: .check_trivy_scan

--- a/gitlab-trivy-checks.yaml
+++ b/gitlab-trivy-checks.yaml
@@ -6,7 +6,7 @@
 
 # Include the new unified template
 include:
-  - remote: 'https://github.com/ambient-innovation/trivy-scanner-templates/releases/latest/download/trivy-scanning.template.yaml'
+  - remote: 'ttps://github.com/ambient-innovation/gitlab-trivy-codequality-template/releases/download/v25.08.05.0/trivy-scanning.template.yaml'
 
 container_scanning:
   extends: .trivy_scanning


### PR DESCRIPTION
This pull request deprecates the existing individual Trivy scanning templates and migrates the repository toward a new, unified scanning approach. The main changes include updating documentation to announce the deprecation, introducing deprecation warnings in the CI templates, and recommending migration to the new `trivy-scanning.template.yaml`. The changes aim to simplify configuration and encourage users to adopt the new, more maintainable solution.

**Deprecation and Migration to Unified Template**

* Added prominent deprecation warnings to `README.md`, `gitlab-trivy-checks.yaml`, and `gitlab-trivy-checks.template.yaml`, instructing users to migrate to the new unified `trivy-scanning.template.yaml` and providing a link to the replacement repository. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R14) [[2]](diffhunk://#diff-e4d8d1552cb4acf8bcf9437035036889b135a40707113416f35dc0e43cc977c8R1-R19) [[3]](diffhunk://#diff-c243b6087d72fa607733a9d0a5a632586d541b9dc52e0103bf559ffa0c581f03L1-R80)
* Updated all templates to display deprecation messages during CI runs, including instructions and migration guide links for users.

**Template and Pipeline Refactoring**

* Deprecated the individual scanning templates (`config-checks`, `license-checks`, `security-checks`) and replaced them with jobs that extend the new unified scanning template, ensuring backward compatibility while guiding users to migrate. [[1]](diffhunk://#diff-c243b6087d72fa607733a9d0a5a632586d541b9dc52e0103bf559ffa0c581f03L1-R80) [[2]](diffhunk://#diff-e4d8d1552cb4acf8bcf9437035036889b135a40707113416f35dc0e43cc977c8R1-R19)
* Removed legacy documentation and configuration details from the `README.md`, replacing them with a migration notice and a pointer to the new unified repository.
* Updated includes and job extensions in the YAML files to reference the new template and structure, aligning with the unified scanning approach. [[1]](diffhunk://#diff-e4d8d1552cb4acf8bcf9437035036889b135a40707113416f35dc0e43cc977c8R1-R19) [[2]](diffhunk://#diff-c243b6087d72fa607733a9d0a5a632586d541b9dc52e0103bf559ffa0c581f03L1-R80)